### PR TITLE
GitHubCI: fix commitlint step in sanitycheck

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,13 +87,15 @@ jobs:
     - name: Install dependencies of commitlint
       run: sudo apt install --yes npm && npm install @commitlint/config-conventional
     - name: Pull our commitlint configuration
-      run: sudo apt install wget && wget https://raw.githubusercontent.com/nblockchain/conventions/master/commitlint.config.ts
+      run: |
+        git clone https://github.com/nblockchain/conventions.git
+        rm -rf conventions/.git/
     - name: Validate current commit (last commit) with commitlint
       if: github.event_name == 'push'
-      run: npx commitlint --from HEAD~1 --to HEAD --verbose
+      run: ./conventions/commitlint.sh --from HEAD~1 --to HEAD --verbose
     - name: Validate PR commits with commitlint
       if: github.event_name == 'pull_request'
-      run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+      run: ./conventions/commitlint.sh --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
     - name: Setup .NET SDK 6.0.x
       uses: actions/setup-dotnet@v1.7.2


### PR DESCRIPTION
We now use a script in conventions repo so that the invocation approach can be defined there (because we've had to downgrade to a previous version and we don't want all consumers of conventions repo to need to know about this, they can just call this script).