### PR TITLE
CI,build: better way to test legacy framework

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,7 @@ jobs:
   sanity_check:
     needs:
     - macOS_dotnet-and-mono
+    - macOS_mono
     - linux_oldLTS_github_dotnet-and-xbuild
     - linux_oldLTS_github_dotnet-and-msbuild
     - linux_oldLTS_vanilla_stockmono
@@ -118,6 +119,33 @@ jobs:
       run: make
     - name: run unit tests
       run: dotnet fsi scripts/runUnitTests.fsx
+
+    - name: install
+      run: |
+        # to clean Debug artifacts first (make install builds in Release config)
+        git clean -fdx
+
+        ./configure.sh
+        make release
+        sudo make install
+
+    - name: run tests
+      run: make check
+    - name: compile this repo's .fsx scripts with fsx
+      run: ./compileFSharpScripts.fsx
+
+  macOS_mono:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: HACK to emulate dotnet uninstall
+      run: sudo rm -f `which dotnet`
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: run unit tests
+      run: fsharpi --define:LEGACY_FRAMEWORK scripts/runUnitTests.fsx
 
     - name: install
       run: |
@@ -471,8 +499,10 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
+    - name: HACK to emulate dotnet uninstall
+      run: del $(where.exe dotnet)
     - name: build in DEBUG mode
-      run: .\make-legacy.bat
+      run: .\make.bat
     - name: run unit tests
       run: .\Tools\fsi.bat scripts\runUnitTests.fsx
 
@@ -481,11 +511,11 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        .\make-legacy.bat release
-        .\make-legacy.bat install
+        .\make.bat release
+        .\make.bat install
 
     - name: run tests
-      run: .\make-legacy.bat check
+      run: .\make.bat check
     - name: compile this repo's .fsx scripts with fsx
       run: .\Tools\fsi.bat compileFSharpScripts.fsx
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,7 +124,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -153,7 +155,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -182,7 +186,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -220,7 +226,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run unit tests
       run: ./scripts/runUnitTests.fsx
@@ -264,7 +272,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -293,7 +303,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -322,7 +334,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -360,7 +374,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run unit tests
       run: ./scripts/runUnitTests.fsx
@@ -404,7 +420,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -440,7 +458,9 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
-        ./configure.sh && sudo make install
+        ./configure.sh
+        make release
+        sudo make install
 
     - name: run tests
       run: make check
@@ -461,6 +481,7 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
+        .\make-legacy.bat release
         .\make-legacy.bat install
 
     - name: run tests
@@ -486,6 +507,7 @@ jobs:
         # to clean Debug artifacts first (make install builds in Release config)
         git clean -fdx
 
+        .\make.bat release
         .\make.bat install
 
     - name: run tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 all:
 	./scripts/build.sh
 
-install:
+release:
+	./scripts/build.sh /p:Configuration=Release
+
+install: release
 	./scripts/install.sh
 
 check:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,13 +5,13 @@
 THIS REPO IS FACING A COMPLETE OVERHAUL/REVAMP/RENOVATION IN ORDER TO SUPPORT .NET6.
 
 Unfinished tasks so far:
-* Try creating a macOS VM for CI that uninstalls .NETCore/.NET6 first, to make sure legacy framework build still works there.
 * Revamp this ReadMe.md file to remove any mentions to Mono or the legacy .NET4.x framework.
 * To reach a v1.0 release, publish fsx as dotnet tool in nuget.
 * Convert the fsx.fsx script into a console project (1.1?) to gain better performance in Windows.
 * Remove legacy framework support (so that build system can converge into .fsx files instead of autotools in Unix + fsx in Windows).
 * Make fsxc always enable warnAsError and fsx always disable it.
 * After doing the above, make both fsx and fsxc always enable warnAsError for the warning described in https://stackoverflow.com/questions/38202685/fsx-script-ignoring-a-function-call-when-i-add-a-parameter-to-it
+* Try creating VMs for CI that uninstall .NETCore/.NET6 completely (not just the dotnet executable removal hack), to make sure legacy framework build still works there.
 
 
 ## Motivation

--- a/make-legacy.bat
+++ b/make-legacy.bat
@@ -1,3 +1,0 @@
-@ECHO OFF
-Tools\fsi.bat scripts\make.fsx %*
-

--- a/make.bat
+++ b/make.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 where /q dotnet
 IF ERRORLEVEL 1 (
-    make-legacy.bat %*
+    Tools\fsi.bat scripts\make.fsx %*
 ) ELSE (
     dotnet fsi scripts\make.fsx %*
 )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
-set -e
+set -euxo
 
-if [ ! -f ./build.config ]; then
-    echo "Please run ./configure.sh first" >&2
-    exit 1
-fi
 source build.config
-
-./scripts/build.sh /p:Configuration=Release
 
 FSX_INSTALL_DIR="$Prefix/lib/fsx"
 BIN_INSTALL_DIR="$Prefix/bin"

--- a/scripts/make.fsx
+++ b/scripts/make.fsx
@@ -200,6 +200,10 @@ match maybeTarget with
 | None
 | Some "all" -> MakeAll() |> ignore
 
+| Some "release" ->
+    let buildConfig = BinaryConfig.Release
+    JustBuild buildConfig
+
 | Some "install" ->
     let buildConfig = BinaryConfig.Release
     JustBuild buildConfig


### PR DESCRIPTION
Instead of running make-legacy.bat directly from CI, we delete
the dotnet executable and prepare make.bat to deal with that.
This has proven so useful that I'm even introducing a new macOS
lane to test legacy framework (via Mono in this case) this way.