### PR TITLE
Fsdk: fix build

### DIFF
--- a/Fsdk/Process.fs
+++ b/Fsdk/Process.fs
@@ -12,18 +12,18 @@ module Process =
     // https://stackoverflow.com/a/961904/544947
     type internal QueuedLock() =
         let innerLock = Object()
-        let ticketsCount = ref 0
-        let ticketToRide = ref 1
+        let mutable ticketsCount = 0
+        let mutable ticketToRide = 1
 
         member __.Enter() =
-            let myTicket = Interlocked.Increment ticketsCount
+            let myTicket = Interlocked.Increment &ticketsCount
             Monitor.Enter innerLock
 
-            while myTicket <> ticketToRide.Value do
+            while myTicket <> Volatile.Read &ticketToRide do
                 Monitor.Wait innerLock |> ignore
 
         member __.Exit() =
-            Interlocked.Increment ticketToRide |> ignore
+            Interlocked.Increment &ticketToRide |> ignore
             Monitor.PulseAll innerLock
             Monitor.Exit innerLock
 

--- a/Fsdk/Process.fs
+++ b/Fsdk/Process.fs
@@ -19,7 +19,7 @@ module Process =
             let myTicket = Interlocked.Increment ticketsCount
             Monitor.Enter innerLock
 
-            while myTicket <> Volatile.Read ticketToRide do
+            while myTicket <> ticketToRide.Value do
                 Monitor.Wait innerLock |> ignore
 
         member __.Exit() =


### PR DESCRIPTION
Somehow, the `macOS--dotnet6-and-mono` and
`linux-*-github--dotnet-*` CI lanes started failing with this compiler error:

```
/home/runner/work/fsx/fsx/Fsdk/Process.fs(22,31): error FS0041: No overloads match for method 'Read'.

Known type of argument: int ref

Available overloads:
 - Volatile.Read(location: inref<bool>) : bool // Argument 'location' doesn't match
 - Volatile.Read(location: inref<byte>) : byte // Argument 'location' doesn't match
 - Volatile.Read(location: inref<float32>) : float32 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<float>) : float // Argument 'location' doesn't match
 - Volatile.Read(location: inref<int16>) : int16 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<int64>) : int64 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<int>) : int // Argument 'location' doesn't match
 - Volatile.Read(location: inref<nativeint>) : nativeint // Argument 'location' doesn't match
 - Volatile.Read(location: inref<sbyte>) : sbyte // Argument 'location' doesn't match
 - Volatile.Read(location: inref<uint16>) : uint16 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<uint32>) : uint32 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<uint64>) : uint64 // Argument 'location' doesn't match
 - Volatile.Read(location: inref<unativeint>) : unativeint // Argument 'location' doesn't match
 - Volatile.Read<'T when 'T: not struct>(location: inref<'T>) : 'T // Argument 'location' doesn't match
```

Which makes me think that they are upgrading to newer .NET versions instead of being pinned...

The build fix works but not sure it's correct at runtime TBH. We will see when we start using the new version of Fsdk nuget package soon...