### PR TITLE
fsx: fix regression that made fsxc misbehave

### DIFF
--- a/version.config
+++ b/version.config
@@ -1,1 +1,1 @@
-BaseVersion=0.6.0
+BaseVersion=0.6.1


### PR DESCRIPTION
In a geewallet's PR[1] I bisected the problem to this commit: dd66eb31d1d5321ee13afd53ff52b6f02e97179d.

So I'm basically reverting that commit here, but I still don't understand why it would cause such a regression. The problem is that fsxc is not able to compile anymore certain scripts and spits some errors that look to be warnings, such as:

```
Error: D:\a\geewallet\geewallet\scripts\bin\downloadUbuntuDeps.fsx.fs(14,1): error FS0020: The result of this expression has type 'int' and is implicitly ignored. Consider using
'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.
[D:\a\geewallet\geewallet\scripts\bin\downloadUbuntuDeps.fsx.fsproj]
```

[1] https://github.com/nblockchain/geewallet/pull/289