### PR TITLE
Fsdk/Misc: fix error message for sourceDir

### DIFF
--- a/Fsdk/Misc.fs
+++ b/Fsdk/Misc.fs
@@ -273,7 +273,7 @@ module Misc =
         if not(sourceDir.Exists) then
             raise
             <| ArgumentException(
-                "Source directory does not exist: " + targetDir.FullName,
+                "Source directory does not exist: " + sourceDir.FullName,
                 "sourceDir"
             )
 


### PR DESCRIPTION
In CopyDirectoryRecursively function when sourceDir dosen't exist. Before targetDir was included in error message, which was wrong and created confusion.