### PR TITLE
Fsdk: add ignoreWarnings optional param

### DIFF
--- a/src/Fsdk/Process.fs
+++ b/src/Fsdk/Process.fs
@@ -152,13 +152,19 @@ module Process =
                 Console.Error.WriteLine fullErrMsg
                 raise <| ProcessSucceededWithWarnings fullErrMsg
 
-        member self.UnwrapDefault() : string =
-            self.Unwrap(
-                sprintf
-                    "Error when running '%s %s'"
-                    self.Details.Command
-                    self.Details.Args
-            )
+        member self.UnwrapDefault(?ignoreWarnings: bool) : string =
+            let ignoreWarnings = defaultArg ignoreWarnings false
+
+            match self.Result with
+            | WarningsOrAmbiguous output when ignoreWarnings ->
+                output.ToString()
+            | _ ->
+                self.Unwrap(
+                    sprintf
+                        "Error when running '%s %s'"
+                        self.Details.Command
+                        self.Details.Args
+                )
 
 
     type ProcessCouldNotStart

--- a/src/Fsdk/Process.fs
+++ b/src/Fsdk/Process.fs
@@ -56,7 +56,9 @@ module Process =
             (
                 subBuffer: list<OutputChunk>,
                 outputType: Option<Standard>
-            ) =
+            ) : StringBuilder =
+            let newStringBuilder = StringBuilder()
+
             subBuffer
             |> List.rev
             |> List.fold
@@ -66,7 +68,7 @@ module Process =
                     else
                         sb
                 )
-                (StringBuilder())
+                newStringBuilder
 
         let Print(subBuffer: list<OutputChunk>) : unit =
             subBuffer


### PR DESCRIPTION
There's many CLIs that surprisingly output their logs to StdErr instead of StdOut even if their exitCode ends up not being higher than zero (e.g. git) so this will be very useful for those, instead of having to create manually a `match` block to check what ProcessResult ended up being.