### PR TITLE
Fsdk/Misc: workaround in FsxOnlyArguments

### DIFF
--- a/src/Fsdk/Misc.fs
+++ b/src/Fsdk/Misc.fs
@@ -95,7 +95,22 @@ module Misc =
 #endif
 
     let FsxOnlyArguments() =
-        let cmdLineArgs = Environment.GetCommandLineArgs() |> List.ofSeq
+        let cmdLineArgs =
+            Environment.GetCommandLineArgs()
+            // Filter out preferreduilang from script args, see https://github.com/dotnet/fsharp/pull/19151
+            |> Seq.filter(fun arg ->
+                not(
+                    arg.StartsWith(
+                        "--preferreduilang:",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                    || arg.StartsWith(
+                        "/preferreduilang:",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+            )
+            |> List.ofSeq
 #if !LEGACY_FRAMEWORK
         if cmdLineArgs.Length = 0 then
             failwith


### PR DESCRIPTION
Filter out `preferreduilang` argument from script args in FsxOnlyArguments() function. This argument started to appear in .NET 10 when running .fsx scripts, breaking existing scripts. It was then removed from fsi.CommandLineArgs, but not from Environment.GetCommandLineArgs(), see [1]. Value fsi.CommandLineArgs can't be used in the library, as it is only available in fsx scripts.

[1] https://github.com/dotnet/fsharp/pull/19151